### PR TITLE
feat: add per-chain inlineRefsFlag capture with refChainStart rule marker

### DIFF
--- a/src/define-origins-and-resolve-ref.ts
+++ b/src/define-origins-and-resolve-ref.ts
@@ -262,10 +262,37 @@ const createDefineOriginsAndResolveRefHook: (rootJso: unknown, options: Internal
 
           const processReferenceWithChildren = (resolvedRefWithSibling: ResolvedRefWithSiblings) => {
             const { refValue, origin, childrenOrigins, firstReferenceKey, lastReferenceKey } = resolvedRefWithSibling as ResolvedRefWithChildrenOrigins
-            const captureFirstReferenceKey = options.firstReferenceKeyProperty && rules?.captureFirstReferenceKey && firstReferenceKey !== undefined
-            const refValueToUse = captureFirstReferenceKey && options.firstReferenceKeyProperty && isObject(refValue)
-              ? copyTargetIfFirstKeyDiffers(refValue as Record<PropertyKey, unknown>, options.firstReferenceKeyProperty, firstReferenceKey)
-              : refValue
+            const captureFirstKey = !!(options.firstReferenceKeyProperty && rules?.captureFirstReferenceKey && firstReferenceKey !== undefined)
+            const captureInlineRefs = !!(options.inlineRefsFlag && rules?.refChainStart && inlineRefsChainCapture !== undefined)
+
+            // Compute expected inline refs for this chain: merge live-captured inner refs,
+            // existing refs already on the target (from prior processing), and the outer ref.
+            const existingTargetInlineRefs = captureInlineRefs && isObject(refValue)
+              ? ((refValue as Record<PropertyKey, unknown>)[options.inlineRefsFlag!] as string[] | undefined) ?? []
+              : []
+            const expectedInlineRefs = captureInlineRefs
+              ? buildInlineRefsChain(inlineRefsChainCapture!, existingTargetInlineRefs, reference.normalized)
+              : undefined
+
+            let refValueToUse: typeof refValue = refValue
+            if ((captureFirstKey || captureInlineRefs) && isObject(refValue)) {
+              const firstKeyDiffers = captureFirstKey
+                && (refValue as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] !== undefined
+                && (refValue as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] !== firstReferenceKey
+              const inlineRefsDiffer = captureInlineRefs
+                && (refValue as Record<PropertyKey, unknown>)[options.inlineRefsFlag!] !== undefined
+                && !inlineRefsEqual((refValue as Record<PropertyKey, unknown>)[options.inlineRefsFlag!] as string[], expectedInlineRefs!)
+
+              if (firstKeyDiffers || inlineRefsDiffer) {
+                refValueToUse = { ...(refValue as Record<PropertyKey, unknown>) }
+                if (captureFirstKey) {
+                  (refValueToUse as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] = firstReferenceKey
+                }
+              } else if (captureFirstKey && (refValue as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] === undefined) {
+                (refValue as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] = firstReferenceKey
+              }
+            }
+
             return {
               value: refValueToUse,
               state: {
@@ -273,6 +300,7 @@ const createDefineOriginsAndResolveRefHook: (rootJso: unknown, options: Internal
                 originParent: origin,
                 originCollector: childrenOrigins,
                 firstReferenceKeyForCapture: undefined,
+                inlineRefsChainCapture: undefined,
               },
               afterHooksHook: () => {
                 const node = state.node[safeKey]
@@ -283,7 +311,15 @@ const createDefineOriginsAndResolveRefHook: (rootJso: unknown, options: Internal
               },
               exitHook: () => {
                 const node = state.node[safeKey]
-                options.inlineRefsFlag && isObject(node) && addRefInlineHistory(node, options.inlineRefsFlag, reference)
+                if (captureInlineRefs && isObject(node)) {
+                  node[options.inlineRefsFlag!] = expectedInlineRefs!
+                } else if (state.inlineRefsChainCapture !== undefined && options.inlineRefsFlag && isObject(node)) {
+                  if (!state.inlineRefsChainCapture.includes(reference.normalized)) {
+                    state.inlineRefsChainCapture.push(reference.normalized)
+                  }
+                } else {
+                  options.inlineRefsFlag && isObject(node) && addRefInlineHistory(node, options.inlineRefsFlag, reference)
+                }
                 options.firstReferenceKeyProperty && isObject(node) && firstReferenceKey !== undefined && setJsoProperty(node, options.firstReferenceKeyProperty, firstReferenceKey)
                 options.lastReferenceKeyProperty && isObject(node) && setJsoProperty(node, options.lastReferenceKeyProperty, lastReferenceKey)
                 if (options.originsFlag && isObject(node) && origin) {
@@ -311,10 +347,16 @@ const createDefineOriginsAndResolveRefHook: (rootJso: unknown, options: Internal
           } else {
             cyclingGuard.add(reference.normalized)
           }
+          let inlineRefsChainCapture: string[] | undefined = undefined
           const previousFirstReferenceKeyForCapture = state.firstReferenceKeyForCapture
+          const previousInlineRefsChainCapture = state.inlineRefsChainCapture
           try {
             if (rules?.captureFirstReferenceKey && options.firstReferenceKeyProperty) {
               state.firstReferenceKeyForCapture = state.firstReferenceKeyForCapture ?? reference.jsonPath.at(-1)?.toString()
+            }
+            if (rules?.refChainStart && options.inlineRefsFlag && state.inlineRefsChainCapture === undefined) {
+              inlineRefsChainCapture = []
+              state.inlineRefsChainCapture = inlineRefsChainCapture
             }
             const firstReferenceKeyForResolve = (rules?.captureFirstReferenceKey && options.firstReferenceKeyProperty) ? state.firstReferenceKeyForCapture : undefined
             const updateLazyParentChainItem: (item: ChainItem, parentValue: unknown | undefined, propertyKey: PropertyKey) => void = (item, parentValue, propertyKey) =>
@@ -398,6 +440,7 @@ const createDefineOriginsAndResolveRefHook: (rootJso: unknown, options: Internal
           } finally {
             cyclingGuard.delete(reference.normalized)
             state.firstReferenceKeyForCapture = previousFirstReferenceKeyForCapture
+            state.inlineRefsChainCapture = previousInlineRefsChainCapture
           }
         }
         return referenceHandler({ path, ref: $ref, safeKey, options, state, value, resolveDefaultReference })
@@ -443,6 +486,29 @@ const addRefInlineHistory: (jso: Record<PropertyKey, unknown>, inlineRefsFlag: s
   }
   const normalized = reference.normalized
   if (!history.includes(normalized)) { history.push(normalized) }
+}
+
+/**
+ * Builds the final inline refs list for a refChainStart chain by merging:
+ * - liveCapture: refs accumulated from inner $refs resolved live during this chain
+ * - existingRefs: refs already on the target from previous (non-refChainStart) processing
+ * - outerNormalized: the ref that initiated this refChainStart resolution
+ * Deduplicates while preserving order (live inner first, then existing, then outer).
+ */
+function buildInlineRefsChain(liveCapture: string[], existingRefs: string[], outerNormalized: string): string[] {
+  const result: string[] = []
+  for (const ref of liveCapture) {
+    if (!result.includes(ref)) { result.push(ref) }
+  }
+  for (const ref of existingRefs) {
+    if (!result.includes(ref)) { result.push(ref) }
+  }
+  if (!result.includes(outerNormalized)) { result.push(outerNormalized) }
+  return result
+}
+
+function inlineRefsEqual(existing: string[], expected: string[]): boolean {
+  return existing.length === expected.length && expected.every((v, i) => existing[i] === v)
 }
 
 /**

--- a/src/define-origins-and-resolve-ref.ts
+++ b/src/define-origins-and-resolve-ref.ts
@@ -268,7 +268,7 @@ const createDefineOriginsAndResolveRefHook: (rootJso: unknown, options: Internal
             // Compute expected inline refs for this chain: merge live-captured inner refs,
             // existing refs already on the target (from prior processing), and the outer ref.
             const existingTargetInlineRefs = captureInlineRefs && isObject(refValue)
-              ? ((refValue as Record<PropertyKey, unknown>)[options.inlineRefsFlag!] as string[] | undefined) ?? []
+              ? refValue[options.inlineRefsFlag!] as string[] | undefined ?? []
               : []
             const expectedInlineRefs = captureInlineRefs
               ? buildInlineRefsChain(inlineRefsChainCapture!, existingTargetInlineRefs, reference.normalized)
@@ -277,19 +277,19 @@ const createDefineOriginsAndResolveRefHook: (rootJso: unknown, options: Internal
             let refValueToUse: typeof refValue = refValue
             if ((captureFirstKey || captureInlineRefs) && isObject(refValue)) {
               const firstKeyDiffers = captureFirstKey
-                && (refValue as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] !== undefined
-                && (refValue as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] !== firstReferenceKey
+                && refValue[options.firstReferenceKeyProperty!] !== undefined
+                && refValue[options.firstReferenceKeyProperty!] !== firstReferenceKey
               const inlineRefsDiffer = captureInlineRefs
-                && (refValue as Record<PropertyKey, unknown>)[options.inlineRefsFlag!] !== undefined
-                && !inlineRefsEqual((refValue as Record<PropertyKey, unknown>)[options.inlineRefsFlag!] as string[], expectedInlineRefs!)
+                && refValue[options.inlineRefsFlag!] !== undefined
+                && !inlineRefsEqual(refValue[options.inlineRefsFlag!] as string[], expectedInlineRefs!)
 
               if (firstKeyDiffers || inlineRefsDiffer) {
-                refValueToUse = { ...(refValue as Record<PropertyKey, unknown>) }
+                refValueToUse = { ...refValue }
                 if (captureFirstKey) {
                   (refValueToUse as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] = firstReferenceKey
                 }
-              } else if (captureFirstKey && (refValue as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] === undefined) {
-                (refValue as Record<PropertyKey, unknown>)[options.firstReferenceKeyProperty!] = firstReferenceKey
+              } else if (captureFirstKey && refValue[options.firstReferenceKeyProperty!] === undefined) {
+                refValue[options.firstReferenceKeyProperty!] = firstReferenceKey
               }
             }
 

--- a/src/define-origins-and-resolve-ref.ts
+++ b/src/define-origins-and-resolve-ref.ts
@@ -496,15 +496,11 @@ const addRefInlineHistory: (jso: Record<PropertyKey, unknown>, inlineRefsFlag: s
  * Deduplicates while preserving order (live inner first, then existing, then outer).
  */
 function buildInlineRefsChain(liveCapture: string[], existingRefs: string[], outerNormalized: string): string[] {
-  const result: string[] = []
-  for (const ref of liveCapture) {
-    if (!result.includes(ref)) { result.push(ref) }
-  }
-  for (const ref of existingRefs) {
-    if (!result.includes(ref)) { result.push(ref) }
-  }
-  if (!result.includes(outerNormalized)) { result.push(outerNormalized) }
-  return result
+  const result = new Set<string>()
+  liveCapture.forEach((ref) => result.add(ref))
+  existingRefs.forEach((ref) => result.add(ref))
+  result.add(outerNormalized)
+  return Array.from(result)
 }
 
 function inlineRefsEqual(existing: string[], expected: string[]): boolean {

--- a/src/rules/asyncapi.ts
+++ b/src/rules/asyncapi.ts
@@ -277,6 +277,7 @@ const messageRules: NormalizationRules = {
 const rootMessageRules: NormalizationRules = {
   ...messageRules,
   captureFirstReferenceKey: true,
+  refChainStart: true,
 }
 
 const parameterRules: NormalizationRules = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,8 @@ export interface DefineOriginsAndResolveRefState extends HasIgnoreTreeUnderSymbo
   syntheticsJumps: Map<unknown, () => unknown>
   /** When set, nested ref resolution reuses this as first reference key (for captureFirstReferenceKey). */
   firstReferenceKeyForCapture?: string
+  /** Accumulates refs during a refChainStart chain; undefined outside such chains. */
+  inlineRefsChainCapture?: string[]
 }
 
 export interface ValidateState extends HasIgnoreTreeUnderSymbols {
@@ -257,6 +259,7 @@ export interface NormalizationRule {
   readonly isExtension?: boolean
   readonly referenceHandler?: ReferenceHandler
   readonly captureFirstReferenceKey?: boolean
+  readonly refChainStart?: boolean
 }
 
 export type MergeAndLiftCombinersSyncCloneHook = SyncCloneHook<MergeAndLiftCombinersState, NormalizationRule>

--- a/test/asyncapi/resolve-ref.reference-object.test.ts
+++ b/test/asyncapi/resolve-ref.reference-object.test.ts
@@ -1108,6 +1108,7 @@ describe('AsyncAPI Reference Object Resolver', () => {
         inlineRefsFlag: TEST_INLINE_REFS_FLAG,
       }) as any
 
+      expect(result.operations.operation1.messages[0][TEST_INLINE_REFS_FLAG]).not.toEqual(result.operations.operation2.messages[0][TEST_INLINE_REFS_FLAG])
       expect(result.operations.operation1.messages[0][TEST_INLINE_REFS_FLAG]).toEqual(['#/components/messages/SharedMessage', '#/channels/channel1/messages/SharedMessage'])
       expect(result.operations.operation2.messages[0][TEST_INLINE_REFS_FLAG]).toEqual(['#/components/messages/SharedMessage', '#/channels/channel2/messages/SharedMessage'])
     })

--- a/test/asyncapi/resolve-ref.reference-object.test.ts
+++ b/test/asyncapi/resolve-ref.reference-object.test.ts
@@ -1,5 +1,5 @@
 import { normalize } from '../../src/normalize'
-import { TEST_FIRST_REFERENCE_KEY_PROPERTY, TEST_LAST_REFERENCE_KEY_PROPERTY, TEST_SYNTHETIC_TITLE_FLAG } from '../helpers'
+import { TEST_FIRST_REFERENCE_KEY_PROPERTY, TEST_INLINE_REFS_FLAG, TEST_LAST_REFERENCE_KEY_PROPERTY, TEST_SYNTHETIC_TITLE_FLAG } from '../helpers'
 import { parseAsyncApiAndAssertValid } from '../helpers/asyncapi'
 
 const NORMALIZATION_OPTIONS_FIRST_REFERENCE_KEY = {
@@ -884,6 +884,232 @@ describe('AsyncAPI Reference Object Resolver', () => {
       expect(result.operations['send-operation'].messages[0]).toBe(result.channels.ChannelID.messages.MessageID)
       // Broken parameter reference should remain unresolved (kept as $ref) in the final spec
       expect(result.channels.ChannelID.parameters.notExistingParameter.$ref).toBe('#/components/parameters/not-existing-parameter')
+    })
+  })
+
+  describe('Inline Refs Flag', () => {
+    it('should produce same message instance when both operations reference the same channel message via identical chains', async () => {
+      const source = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        channels: {
+          channel1: {
+            messages: {
+              SharedMessage: {
+                payload: {
+                  type: 'object',
+                },
+              },
+            },
+          },
+        },
+        operations: {
+          operation1: {
+            action: 'send',
+            channel: { $ref: '#/channels/channel1' },
+            messages: [
+              { $ref: '#/channels/channel1/messages/SharedMessage' },
+            ],
+          },
+          operation2: {
+            action: 'receive',
+            channel: { $ref: '#/channels/channel1' },
+            messages: [
+              { $ref: '#/channels/channel1/messages/SharedMessage' },
+            ],
+          },
+        },
+      }
+
+      await parseAsyncApiAndAssertValid(source)
+
+      const result = normalize(source, {
+        inlineRefsFlag: TEST_INLINE_REFS_FLAG,
+      }) as any
+
+      // Both operations resolve through identical chains — expected inlineRefsFlag is the same,
+      // so no copy is needed and they share the same resolved instance.
+      expect(result.operations.operation1.messages[0]).toBe(result.operations.operation2.messages[0])
+      expect(result.operations.operation1.messages[0][TEST_INLINE_REFS_FLAG]).toEqual(['#/channels/channel1/messages/SharedMessage'])
+    })
+
+    it('should capture inline refs for channel messages without creating chain-specific copies', async () => {
+      const source = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        channels: {
+          channel1: {
+            messages: {
+              SharedMessage: {
+                $ref: '#/components/messages/SharedMessage',
+              },
+            },
+          },
+        },
+        operations: {
+          operation: {
+            action: 'send',
+            channel: { $ref: '#/channels/channel1' },
+            messages: [
+              { $ref: '#/channels/channel1/messages/SharedMessage' },
+            ],
+          }
+        },
+        components: {
+          messages: {
+            SharedMessage: {
+              payload: {
+                type: 'object',
+              },
+            },
+          },
+        },
+      }
+
+      await parseAsyncApiAndAssertValid(source)
+
+      const result = normalize(source, {
+        inlineRefsFlag: TEST_INLINE_REFS_FLAG,
+      }) as any
+
+      // Channel message resolution uses normal (non-refChainStart) processing,
+      // so inlineRefsFlag is set via addRefInlineHistory directly.
+      expect(result.channels.channel1.messages.SharedMessage[TEST_INLINE_REFS_FLAG]).toEqual(['#/components/messages/SharedMessage'])
+      expect(result.operations.operation.messages[0][TEST_INLINE_REFS_FLAG]).toEqual(['#/components/messages/SharedMessage', '#/channels/channel1/messages/SharedMessage'])
+    })
+
+    it('should capture inline refs and first reference key together using a single copy per operation', async () => {
+      const source = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        channels: {
+          channel1: {
+            messages: {
+              SharedMessage: {
+                $ref: '#/components/messages/SharedMessage',
+              },
+            },
+          },
+          channel2: {
+            messages: {
+              SharedMessage: {
+                $ref: '#/components/messages/SharedMessage',
+              },
+            },
+          },
+        },
+        operations: {
+          operation1: {
+            action: 'send',
+            channel: { $ref: '#/channels/channel1' },
+            messages: [
+              { $ref: '#/channels/channel1/messages/SharedMessage' },
+            ],
+          },
+          operation2: {
+            action: 'send',
+            channel: { $ref: '#/channels/channel2' },
+            messages: [
+              { $ref: '#/channels/channel2/messages/SharedMessage' },
+            ],
+          },
+        },
+        components: {
+          messages: {
+            SharedMessage: {
+              payload: {
+                type: 'object',
+              },
+            },
+          },
+        },
+      }
+
+      await parseAsyncApiAndAssertValid(source)
+
+      const result = normalize(source, {
+        inlineRefsFlag: TEST_INLINE_REFS_FLAG,
+        firstReferenceKeyProperty: TEST_FIRST_REFERENCE_KEY_PROPERTY,
+      }) as any
+
+      // Each operation resolves through a different channel path and gets its own copy
+      // with both flags set in a single copy (not two separate copies).
+      expect(result.operations.operation1.messages[0]).not.toBe(result.operations.operation2.messages[0])
+
+      expect(result.operations.operation1.messages[0][TEST_INLINE_REFS_FLAG]).toEqual(['#/components/messages/SharedMessage', '#/channels/channel1/messages/SharedMessage'])
+      expect(result.operations.operation2.messages[0][TEST_INLINE_REFS_FLAG]).toEqual(['#/components/messages/SharedMessage', '#/channels/channel2/messages/SharedMessage'])
+
+      expect(result.operations.operation1.messages[0][TEST_FIRST_REFERENCE_KEY_PROPERTY]).toBe('SharedMessage')
+      expect(result.operations.operation2.messages[0][TEST_FIRST_REFERENCE_KEY_PROPERTY]).toBe('SharedMessage')
+    })
+
+    it('should capture different inline refs flags for message references in different operations', async () => {
+      const source = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        channels: {
+          channel1: {
+            messages: {
+              SharedMessage: {
+                $ref: '#/components/messages/SharedMessage',
+              },
+            },
+          },
+          channel2: {
+            messages: {
+              SharedMessage: {
+                $ref: '#/components/messages/SharedMessage',
+              },
+            },
+          },
+        },
+        operations: {
+          operation1: {
+            action: 'send',
+            channel: { $ref: '#/channels/channel1' },
+            messages: [
+              { $ref: '#/channels/channel1/messages/SharedMessage' },
+            ],
+          },
+          operation2: {
+            action: 'send',
+            channel: { $ref: '#/channels/channel2' },
+            messages: [
+              { $ref: '#/channels/channel2/messages/SharedMessage' },
+            ],
+          },
+        },
+        components: {
+          messages: {
+            SharedMessage: {
+              payload: {
+                type: 'object',
+              },
+            },
+          },
+        },
+      }
+
+      await parseAsyncApiAndAssertValid(source)
+
+      const result = normalize(source, {
+        inlineRefsFlag: TEST_INLINE_REFS_FLAG,
+      }) as any
+
+      expect(result.operations.operation1.messages[0][TEST_INLINE_REFS_FLAG]).toEqual(['#/components/messages/SharedMessage', '#/channels/channel1/messages/SharedMessage'])
+      expect(result.operations.operation2.messages[0][TEST_INLINE_REFS_FLAG]).toEqual(['#/components/messages/SharedMessage', '#/channels/channel2/messages/SharedMessage'])
     })
   })
 })


### PR DESCRIPTION
- Adds `refChainStart?: boolean` to `NormalizationRule` to mark the boundary
  where per-chain `inlineRefsFlag` accumulation begins. Applied to
  `rootMessageRules` in `src/rules/asyncapi.ts`.
- Adds `inlineRefsChainCapture?: string[]` to `DefineOriginsAndResolveRefState`
  as a shared array (by reference) propagated through inner hooks via `...state`
  spread. Inner hooks accumulate into it instead of mutating the resolved object
  directly; the outer (refChainStart) exitHook applies the final merged list.
- Adds `buildInlineRefsChain` and `inlineRefsEqual` helpers in
  `src/define-origins-and-resolve-ref.ts`. The chain builder merges live-captured
  inner refs, any existing refs already on the target (set by prior non-chain
  processing), and the outer ref — with deduplication and stable ordering.
- Replaces `copyTargetIfFirstKeyDiffers` in `processReferenceWithChildren` with
  a combined copy decision: a single `{ ...target }` shallow copy is made when
  either `firstReferenceKey` or `inlineRefsFlag` would differ; both are handled
  in one copy rather than two.
- All existing tests pass. Four new tests added under `describe('Inline Refs Flag')`.