### PR TITLE
Normalize public contacts and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,8 @@ Please, follow these guidelines to make the contribution process easy and effect
 
 ## Contributor License Agreement
 
-You must sign the [Contributor License Agreement](https://pages.netcracker.com/cla-main.html) in order to contribute.
+You must sign the [Contributor License Agreement](https://github.com/Netcracker/qubership-workflow-hub/blob/main/CLA/cla.md) in order to contribute.
 
 ## Code of Conduct
 
 Please make sure to read and follow the [Code of Conduct](CODE-OF-CONDUCT.md).
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,13 @@
-# Security Reporting Process
+# Security Policy
+
+## Reporting a Vulnerability
 
 Please, report any security issue to `opensourcegroup@netcracker.com` where the issue will be triaged appropriately.
 
 If you know of a publicly disclosed security vulnerability please IMMEDIATELY email `opensourcegroup@netcracker.com`
 to inform the team about the vulnerability, so we may start the patch, release, and communication process.
 
-# Security Release Process
+## Security Release Process
 
 If the vulnerability is found in the latest stable release, then it would be fixed in patch version for that release.
 E.g., issue is found in 2.5.0 release, then 2.5.1 version with a fix will be released.
@@ -13,4 +15,3 @@ By default, older versions will not have security releases.
 
 If the issue doesn't affect any existing public releases, the fix for medium and high issues is performed
 in a main branch before releasing a new version. For low priority issues the fix can be planned for future releases.
-


### PR DESCRIPTION
## Summary

- Normalize public contact files and example email addresses.
- Keep API support and repository feedback contacts aligned with approved addresses.
- Replace personal-looking examples with neutral example data where applicable.

## Changed files

- CONTRIBUTING.md
- SECURITY.md

## Commit

8629d20 chore: normalize public contacts and examples
 CONTRIBUTING.md | 3 +--
 SECURITY.md     | 7 ++++---
 2 files changed, 5 insertions(+), 5 deletions(-)
