### PR TITLE
chore: adopt split ddlapi entries; move parser imports to /parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@asyncapi/parser": "3.4.0",
-        "@netcracker/qubership-apihub-graphapi": "1.0.10",
+        "@netcracker/qubership-apihub-graphapi": "dev",
         "@netcracker/qubership-apihub-npm-gitflow": "3.1.1",
         "@types/jest": "29.5.2",
         "@types/object-hash": "3.0.6",
@@ -1954,19 +1954,20 @@
       "license": "MIT"
     },
     "node_modules/@netcracker/qubership-apihub-ddlapi": {
-      "version": "0.1.0-feature-ddl.20260608130627",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-ddlapi/0.1.0-feature-ddl.20260608130627/40d60df3e39391f125d417d38c9086629934135d",
-      "integrity": "sha512-tK1zQY+1bIEAcP9Sv/eFPsqylbWwEFcXooAS5TapZiUpNEWvHJv7UuFLMBfztXolnFvObXyHQ9K1VvexHmfF4w==",
+      "version": "1.0.0-feature-ddl.20260701153302",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-ddlapi/1.0.0-feature-ddl.20260701153302/e83d626fd81e4c149dc86ad2ed8efa4a818fe8a0",
+      "integrity": "sha512-9R4vEgcMR4VKYSDSinAUX7YR/YRNgmvN3SrBHVIAfJyctfZzjxIFG/SR85tuJldi6HOKoklaJcH1hpf5SFuIlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pgsql/types": "^17.6.2",
-        "pgsql-parser": "^17.9.15"
+        "@pgsql/types": "17.6.2",
+        "libpg-query": "17.7.3",
+        "pgsql-deparser": "17.18.3"
       }
     },
     "node_modules/@netcracker/qubership-apihub-graphapi": {
-      "version": "1.0.10",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-graphapi/1.0.10/5ae05732e753fa2764af008dd7a837029a7e5822",
-      "integrity": "sha512-sHGPNujgLmez2Ct/4P1HYo7Ph/w/3RluP3sJ+fn1H1z6VuDwBf9FOBk2PzwHfqIcOiO4/TuGNat0E5t6wDrqwQ==",
+      "version": "1.0.11-dev.20260623145927",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-graphapi/1.0.11-dev.20260623145927/0f9119f881b41556e94815f64e390fbf1f095324",
+      "integrity": "sha512-dVRkVQ5rROz5ZN4hNjOSuVslBGQKeEGrkJhswsXzt1usAD+VaO4lCfDGafMDnJDCkGNmVzT00OjJ5z3TqgD28w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0"
@@ -8447,17 +8448,6 @@
       "dependencies": {
         "@pgsql/quotes": "17.1.0",
         "@pgsql/types": "^17.6.2"
-      }
-    },
-    "node_modules/pgsql-parser": {
-      "version": "17.9.15",
-      "resolved": "https://registry.npmjs.org/pgsql-parser/-/pgsql-parser-17.9.15.tgz",
-      "integrity": "sha512-6+k0EtTn0CEQTR5v2APARu9En4vm46TpmpdMSfKDHkZwWZuEc08B7SeVg32VxNQ2HD5xk+dQ9TD0k9m+S+vFgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@pgsql/types": "^17.6.2",
-        "libpg-query": "17.7.3",
-        "pgsql-deparser": "17.18.3"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "simplify"
   ],
   "dependencies": {
-    "@netcracker/qubership-apihub-ddlapi": "feature-ddl",
+    "@netcracker/qubership-apihub-ddlapi": "feature-externalize-pqparser",
     "@netcracker/qubership-apihub-json-crawl": "1.2.1",
     "object-hash": "3.0.0",
     "fast-equals": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "simplify"
   ],
   "dependencies": {
-    "@netcracker/qubership-apihub-ddlapi": "feature-externalize-pqparser",
+    "@netcracker/qubership-apihub-ddlapi": "feature-ddl",
     "@netcracker/qubership-apihub-json-crawl": "1.2.1",
     "object-hash": "3.0.0",
     "fast-equals": "4.0.3",

--- a/test/ddlapi/detect.test.ts
+++ b/test/ddlapi/detect.test.ts
@@ -1,4 +1,4 @@
-import { buildFromDdl } from '@netcracker/qubership-apihub-ddlapi'
+import { buildFromDdl } from '@netcracker/qubership-apihub-ddlapi/parser'
 import {
   normalize,
   resolveSpec,

--- a/test/ddlapi/partial-realm.test.ts
+++ b/test/ddlapi/partial-realm.test.ts
@@ -1,4 +1,5 @@
-import { buildFromDdl, DdlNonFatalError, Realm } from '@netcracker/qubership-apihub-ddlapi'
+import { Realm } from '@netcracker/qubership-apihub-ddlapi'
+import { buildFromDdl, DdlNonFatalError } from '@netcracker/qubership-apihub-ddlapi/parser'
 import { normalize, DDL_API_NORMALIZE_OPTIONS } from '../../src'
 import { commonOriginsCheck, TEST_ORIGINS_FLAG } from '../helpers'
 

--- a/test/ddlapi/smoke.test.ts
+++ b/test/ddlapi/smoke.test.ts
@@ -1,8 +1,8 @@
-import { buildFromDdl } from '@netcracker/qubership-apihub-ddlapi'
+import { buildFromDdl } from '@netcracker/qubership-apihub-ddlapi/parser'
 
-// Smoke test: the ddlapi library is linked and importable from its package root.
+// Smoke test: the ddlapi parser is linked and importable from the '/parser' entry.
 describe('ddlapi link smoke test', () => {
-  it('buildFromDdl returns a Realm from the package root', async () => {
+  it('buildFromDdl returns a Realm from the parser entry', async () => {
     const realm = await buildFromDdl('CREATE TABLE t(id int)')
 
     expect(realm).toMatchObject({

--- a/test/ddlapi/validate.test.ts
+++ b/test/ddlapi/validate.test.ts
@@ -1,5 +1,4 @@
 import {
-  buildFromDdl,
   columnType,
   comment,
   integerType,
@@ -12,6 +11,7 @@ import {
   ReferenceOption,
   PgAttrKind,
 } from '@netcracker/qubership-apihub-ddlapi'
+import { buildFromDdl } from '@netcracker/qubership-apihub-ddlapi/parser'
 import { normalize, DDL_API_NORMALIZE_OPTIONS } from '../../src'
 import { buildRealmAndAssertValid } from '../helpers/ddlapi'
 

--- a/test/helpers/ddlapi.ts
+++ b/test/helpers/ddlapi.ts
@@ -1,4 +1,5 @@
-import { buildFromDdl, DdlNonFatalError, Realm } from '@netcracker/qubership-apihub-ddlapi'
+import { Realm } from '@netcracker/qubership-apihub-ddlapi'
+import { buildFromDdl, DdlNonFatalError } from '@netcracker/qubership-apihub-ddlapi/parser'
 import 'jest-extended'
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "bundler",         /* Honor package `exports` (matches the Vite/Rollup bundle); required for subpath entries like ddlapi/parser. */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
Bump @netcracker/qubership-apihub-ddlapi to feature-externalize-pqparser, which splits its public API into a parser-free model root and a separate '/parser' entry that carries the pgsql-parser/libpg-query WASM.

api-unifier's production code only ever used the model vocabulary, so src/ is unchanged. The test fixtures that parse real DDL now import buildFromDdl / DdlNonFatalError from '@netcracker/qubership-apihub-ddlapi/parser', keeping model symbols (Realm, factories, enums) on the root entry.

Switch moduleResolution from "node" to "bundler" so TypeScript honors the package `exports` map (matching how Vite/Rollup bundle) and can resolve the '/parser' subpath. No file-extension churn (unlike node16/nodenext); deep deps (@asyncapi/parser/esm/*, graphql/utilities) still resolve.